### PR TITLE
docs: fix broken link to Juju config

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ This charm provides a Dell PowerFlex storage backend for use with the Cinder cha
 
 This section covers common and/or important configuration options. See file `config.yaml` for the full list of options, along with their descriptions and default values. See the [Juju documentation][juju-docs-config-apps] for details on configuring applications.
 
+[juju-docs-config-apps]: https://juju.is/docs/juju/juju-config
+
 ### `powerflexgw-ip`
 
 The PowerFlex Gateway IP or hostname.


### PR DESCRIPTION
The "Juju documentation" link doesn't go anywhere. I've assumed that you want to go to the main page on configuration in the Juju docs, and added that as the link destination.