### PR TITLE
feat: add status checks for resource available and service installed

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-To make contributions to this charm, you'll need a working [development setup](https://juju.is/docs/sdk/dev-setup).
+To make contributions to this charm, you'll need a working [development setup](https://documentation.ubuntu.com/juju/3.6/howto/manage-your-deployment/#set-up-your-deployment-local-testing-and-development).
 
 You can create an environment for development with `tox`:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 git+https://github.com/juju/charm-helpers#egg=charmhelpers
-ops
+ops<3
 git+https://opendev.org/openstack/charm-ops-openstack#egg=ops_openstack
 jinja2
 netifaces


### PR DESCRIPTION
This PR adds the resource and service installed checks that the powerflex-cinder-charm has.

In addition, a couple of small changes:
 * Restrict `ops` to versions lower than 3.0 (ops 3.0 will drop support for Python 3.8, which means dropping support for Ubuntu 20.04 as a base -- I'm assuming that 20.04 is still important here).
 * Updates a link to Juju documentation in CONTRIBUTING.md that has moved.