### PR TITLE
ci: store charmcraft logs on failure to upload charm

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,3 +19,10 @@ jobs:
           credentials: "${{ secrets.CHARMHUB_TOKEN }}"
           github-token: ${{ secrets.GITHUB_TOKEN }}
           channel: "latest/stable"
+
+      - name: Archive charmcraft logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: charmcraft-logs
+          path: /home/runner/.local/state/charmcraft/log/*.log


### PR DESCRIPTION
The PR adds a new final step to the `publish` workflow that stores the Charmcraft logs if uploading the charm fails, for easier debugging when things go wrong.